### PR TITLE
他のライブラリから利用可能にするためにpackage.jsonを更新

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,10 @@
   "name": "@shiguredo/rnnoise-wasm",
   "version": "0.0.0",
   "description": "TODO",
+  "main": "dist/rnnoise.js",
+  "module": "dist/rnnoise.js",
   "scripts": {
-    "build": "rollup -c ./rollup.config.js",
+    "build": "rollup -c ./rollup.config.js && tsc --emitDeclarationOnly",
     "lint": "eslint --ext .ts ./src",
     "fmt": "prettier --write src",
     "start": "npx serve -S -l 8080 ."


### PR DESCRIPTION
他のライブラリの依存に指定可能にするために、package.jsonに以下を追加:
- `main`および`module`項目
- d.tsファイルを出力するための`tsc --emitDeclarationOnly`呼び出し

※ 最終的にはrollupの設定ファイルも含めて見直した方が良いけれど、当面の暫定対処