### PR TITLE
APIドキュメントを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ yarn.lock
 
 # Ignore generated files by build.sh
 src/rnnoise_wasm.js
+
+# Ignore generated docs
+apidoc/

--- a/TYPEDOC.md
+++ b/TYPEDOC.md
@@ -1,0 +1,39 @@
+# rnnoise-wasm API Document
+
+[RNNoise](https://github.com/shiguredo/rnnoise)をwasmにビルドして、TypeScriptから利用するためのライブラリです。
+
+WebAssemblyのSIMDに対応しているブラウザでは、自動的にSIMD版のwasmビルドが使用されます。
+
+## About Shiguredo's open source software
+
+We will not respond to PRs or issues that have not been discussed on Discord. Also, Discord is only available in Japanese.
+
+Please read https://github.com/shiguredo/oss/blob/master/README.en.md before use.
+
+## 時雨堂のオープンソースソフトウェアについて
+
+利用前に https://github.com/shiguredo/oss をお読みください。
+
+
+## ライセンス
+
+[Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+```
+Copyright 2021-2021, Takeru Ohta (Original Author)
+Copyright 2021-2021, Shiguredo Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```
+
+生成された wasm ファイルのライセンスについては [rnnoise/COPYING](https://github.com/shiguredo/rnnoise) を参照してください。

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "serve": "^13.0.2",
         "ts-jest": "^27.1.2",
         "ts-node": "^10.4.0",
+        "typedoc": "^0.22.10",
         "typescript": "^4.5.4"
       }
     },
@@ -4379,6 +4380,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonc-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
+      "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
+      "dev": true
+    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -4452,6 +4459,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
+    },
     "node_modules/magic-string": {
       "version": "0.25.7",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
@@ -4498,6 +4511,18 @@
       "dev": true,
       "dependencies": {
         "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/marked": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-3.0.8.tgz",
+      "integrity": "sha512-0gVrAjo5m0VZSJb4rpL59K1unJAMb/hm8HRXqasD8VeC8m91ytDPMritgFSlKonfdt+rRYYpP/JfLxgIX8yoSw==",
+      "dev": true,
+      "bin": {
+        "marked": "bin/marked"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/merge-stream": {
@@ -5369,6 +5394,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/shiki": {
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.15.tgz",
+      "integrity": "sha512-/Y0z9IzhJ8nD9nbceORCqu6NgT9X6I8Fk8c3SICHI5NbZRLdZYFaB233gwct9sU0vvSypyaL/qaKvzyQGJBZSw==",
+      "dev": true,
+      "dependencies": {
+        "jsonc-parser": "^3.0.0",
+        "vscode-oniguruma": "^1.6.1",
+        "vscode-textmate": "5.2.0"
+      }
+    },
     "node_modules/signal-exit": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.6.tgz",
@@ -5809,6 +5845,28 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "node_modules/typedoc": {
+      "version": "0.22.10",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.10.tgz",
+      "integrity": "sha512-hQYZ4WtoMZ61wDC6w10kxA42+jclWngdmztNZsDvIz7BMJg7F2xnT+uYsUa7OluyKossdFj9E9Ye4QOZKTy8SA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.2.0",
+        "lunr": "^2.3.9",
+        "marked": "^3.0.8",
+        "minimatch": "^3.0.4",
+        "shiki": "^0.9.12"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 12.10.0"
+      },
+      "peerDependencies": {
+        "typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x || 4.5.x"
+      }
+    },
     "node_modules/typescript": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
@@ -5887,6 +5945,18 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/vscode-oniguruma": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.1.tgz",
+      "integrity": "sha512-vc4WhSIaVpgJ0jJIejjYxPvURJavX6QG41vu0mGhqywMkQqulezEqEQ3cO3gc8GvcOpX6ycmKGqRoROEMBNXTQ==",
+      "dev": true
+    },
+    "node_modules/vscode-textmate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
+      "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
+      "dev": true
     },
     "node_modules/w3c-hr-time": {
       "version": "1.0.2",
@@ -9445,6 +9515,12 @@
         "minimist": "^1.2.5"
       }
     },
+    "jsonc-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
+      "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
+      "dev": true
+    },
     "kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -9503,6 +9579,12 @@
         "yallist": "^4.0.0"
       }
     },
+    "lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
+    },
     "magic-string": {
       "version": "0.25.7",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
@@ -9543,6 +9625,12 @@
       "requires": {
         "tmpl": "1.0.5"
       }
+    },
+    "marked": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-3.0.8.tgz",
+      "integrity": "sha512-0gVrAjo5m0VZSJb4rpL59K1unJAMb/hm8HRXqasD8VeC8m91ytDPMritgFSlKonfdt+rRYYpP/JfLxgIX8yoSw==",
+      "dev": true
     },
     "merge-stream": {
       "version": "2.0.0",
@@ -10192,6 +10280,17 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
     },
+    "shiki": {
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.15.tgz",
+      "integrity": "sha512-/Y0z9IzhJ8nD9nbceORCqu6NgT9X6I8Fk8c3SICHI5NbZRLdZYFaB233gwct9sU0vvSypyaL/qaKvzyQGJBZSw==",
+      "dev": true,
+      "requires": {
+        "jsonc-parser": "^3.0.0",
+        "vscode-oniguruma": "^1.6.1",
+        "vscode-textmate": "5.2.0"
+      }
+    },
     "signal-exit": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.6.tgz",
@@ -10503,6 +10602,19 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "typedoc": {
+      "version": "0.22.10",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.10.tgz",
+      "integrity": "sha512-hQYZ4WtoMZ61wDC6w10kxA42+jclWngdmztNZsDvIz7BMJg7F2xnT+uYsUa7OluyKossdFj9E9Ye4QOZKTy8SA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.2.0",
+        "lunr": "^2.3.9",
+        "marked": "^3.0.8",
+        "minimatch": "^3.0.4",
+        "shiki": "^0.9.12"
+      }
+    },
     "typescript": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
@@ -10563,6 +10675,18 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+      "dev": true
+    },
+    "vscode-oniguruma": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.1.tgz",
+      "integrity": "sha512-vc4WhSIaVpgJ0jJIejjYxPvURJavX6QG41vu0mGhqywMkQqulezEqEQ3cO3gc8GvcOpX6ycmKGqRoROEMBNXTQ==",
+      "dev": true
+    },
+    "vscode-textmate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
+      "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
       "dev": true
     },
     "w3c-hr-time": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "rollup -c ./rollup.config.js && tsc --emitDeclarationOnly",
     "lint": "eslint --ext .ts ./src",
     "fmt": "prettier --write src",
-    "test": "jest"
+    "test": "jest",
+    "doc": "typedoc"
   },
   "repository": {
     "type": "git",
@@ -41,6 +42,7 @@
     "serve": "^13.0.2",
     "ts-jest": "^27.1.2",
     "ts-node": "^10.4.0",
+    "typedoc": "^0.22.10",
     "typescript": "^4.5.4"
   },
   "dependencies": {

--- a/src/rnnoise.ts
+++ b/src/rnnoise.ts
@@ -2,21 +2,41 @@ import { simd } from "wasm-feature-detect";
 import loadRnnoiseModule from "./rnnoise_wasm.js";
 import { RnnoiseModule, DenoiseState, F32Ptr } from "./rnnoise_wasm.js";
 
-class RnnoiseOptions {
+/**
+ * {@link Rnnoise.load} 関数に指定可能なオプション
+ */
 interface RnnoiseOptions {
+  /**
+   * wasm ファイルの配置先ディレクトリパス
+   *
+   * デフォルトでは `rnnoise.js` の配置先と同じディレクトリが使用されます
+   */
   assetsPath?: string;
 
-  // 開発者向け
+  /**
+   * @internal
+   *
+   * 使用する wasm ファイルの名前（テスト用オプション）
+   */
   wasmFileName?: string;
 }
 
+/**
+ * WebAssembly 用にビルドした [RNNoise](https://github.com/shiguredo/rnnoise) を用いて音声データのノイズ抑制を行うためのクラス
+ *
+ * インスタンスを作成するためには {@link Rnnoise.load} 関数を使用してください
+ */
 class Rnnoise {
   private rnnoiseModule: RnnoiseModule;
   private denoiseState: DenoiseState;
   private pcmInputBuf: F32Ptr;
   private pcmOutputBuf: F32Ptr;
 
+  /**
+   * 一度の {@link Rnnoise.processFrame} メソッド呼び出しで処理可能なサンプル数
+   */
   readonly frameSize: number;
+
   private constructor(rnnoiseModule: RnnoiseModule) {
     this.rnnoiseModule = rnnoiseModule;
     this.denoiseState = rnnoiseModule._rnnoise_create();
@@ -33,6 +53,15 @@ class Rnnoise {
     this.pcmOutputBuf = pcmOutputBuf;
   }
 
+  /**
+   * wasm ファイルをロードして {@link Rnnoise} のインスタンスを生成する関数
+   *
+   * @param options 指定可能なオプション群
+   * @returns 生成された {@link Rnnoise} インスタンス
+   *
+   * @remarks
+   * 実行環境が WebAssembly の SIMD に対応している場合には、SIMD 版の wasm ファイルがロードされます
+   */
   static async load(options: RnnoiseOptions = {}): Promise<Rnnoise> {
     const rnnoiseModule = await simd().then((isSupported) => {
       return loadRnnoiseModule({
@@ -59,7 +88,24 @@ class Rnnoise {
     return Promise.resolve(new Rnnoise(rnnoiseModule));
   }
 
-  // 16-bit PCM
+  /**
+   * 音声フレームにノイズ抑制処理を適用するメソッド
+   *
+   * @param frame ノイズ抑制処理の対象となる音声フレーム
+
+   * @returns
+   * VAD (voice-activity-detection) の結果を返します
+   *
+   * 結果の範囲は0から1で、値が大きいほど、入力音声フレームに人の声が含まれている可能性が高いことを意味します
+   *
+   * @throws
+   * 入力音声フレームに含まれるサンプルの数 (`frame.length`) が {@link Rnnoise.frameSize} と異なる場合にエラーが送出されます
+   *
+   * @remarks
+   * RNNoise は入力音声フレームが 16ビットPCM であると仮定しているため、
+   * それ以外のフォーマットのフレームを処理したい場合には、
+   * 呼び出し側で事前に変換を行っておく必要があります
+   */
   processFrame(frame: Float32Array): number {
     if (frame.length != this.frameSize) {
       throw Error(`Expected frame size ${this.frameSize}, but got ${frame.length}`);

--- a/src/rnnoise.ts
+++ b/src/rnnoise.ts
@@ -3,6 +3,7 @@ import loadRnnoiseModule from "./rnnoise_wasm.js";
 import { RnnoiseModule, DenoiseState, F32Ptr } from "./rnnoise_wasm.js";
 
 class RnnoiseOptions {
+interface RnnoiseOptions {
   assetsPath?: string;
 
   // 開発者向け

--- a/src/rnnoise.ts
+++ b/src/rnnoise.ts
@@ -15,8 +15,8 @@ class Rnnoise {
   private denoiseState: DenoiseState;
   private pcmInputBuf: F32Ptr;
   private pcmOutputBuf: F32Ptr;
-  private frameSize: number;
 
+  readonly frameSize: number;
   private constructor(rnnoiseModule: RnnoiseModule) {
     this.rnnoiseModule = rnnoiseModule;
     this.denoiseState = rnnoiseModule._rnnoise_create();
@@ -61,8 +61,8 @@ class Rnnoise {
 
   // 16-bit PCM
   processFrame(frame: Float32Array): number {
-    if (frame.length != this.getFrameSize()) {
-      throw Error(`Expected frame size ${this.getFrameSize()}, but got ${frame.length}`);
+    if (frame.length != this.frameSize) {
+      throw Error(`Expected frame size ${this.frameSize}, but got ${frame.length}`);
     }
 
     const pcmInputIndex = this.pcmInputBuf / 4;
@@ -73,10 +73,6 @@ class Rnnoise {
     frame.set(this.rnnoiseModule.HEAPF32.subarray(pcmOutputIndex, pcmOutputIndex + this.frameSize));
 
     return vad;
-  }
-
-  getFrameSize(): number {
-    return this.frameSize;
   }
 }
 

--- a/typedoc.json
+++ b/typedoc.json
@@ -4,6 +4,7 @@
   "disableSources": true,
   "excludePrivate": true,
   "excludeProtected": true,
+  "excludeInternal": true,
   "readme": "./TYPEDOC.md",
   "out": "apidoc"
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,9 @@
+{
+  "entryPoints": ["src/rnnoise.ts"],
+  "tsconfig": "./tsconfig.json",
+  "disableSources": true,
+  "excludePrivate": true,
+  "excludeProtected": true,
+  "readme": "./TYPEDOC.md",
+  "out": "apidoc"
+}


### PR DESCRIPTION
ドキュメント関連の変更点:
- `typedoc`パッケージを`devDependencies`に追加
- typedoc用の設定ファイル (typedoc.json) を追加
- `TYPEDOC.md`を追加 (package-levelドキュメント)
- `src/rnnoise.ts`の各クラス・メソッド・関数にドキュメントコメントを追加

また、ドキュメントとは直接関係ない、軽微なインタフェース変更も含まれています:
- `RnnoiseOptions`を`class`から`interface`に変更（元々classになっていたのがミス）
- `Rnnoise.getFrameSize()`メソッドを廃止して、代わりに`frameSize`プロパティのアクセス権をreadonly publicに変更