### PR TITLE
npmリリース向けにREADME.mdおよびpackage.jsonを更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,14 @@ $ npm ls
 
 TypeScript での使用方法は次のようになります:
 ```typescript
-import { Rnnoise } from "@shigredo/rnnoise-wasm/"
+import { Rnnoise } from "@shigredo/rnnoise-wasm/";
 
 // RNNoise の wasm ファイルをロード
-Rnnoise.load().then(|rnnoise| {
+Rnnoise.load().then((rnnoise) => {
     // 音声フレームにノイズ抑制処理を適用する
     const frame = new Float32Array(...);
     rnnoise.processFrame(frame);
-})
+});
 ```
 
 ## ライセンス

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 rnnoise-wasm
 ============
 
-[RNNoise](https://github.com/shiguredo/rnnoise)をwasmにビルドして、TypeScriptから利用するためのライブラリです。
+[RNNoise](https://github.com/shiguredo/rnnoise) を WebAssembly (wasm) にビルドして
+JavaScript や TypeScript から利用するためのライブラリです。
 
-WebAssemblyのSIMDに対応しているブラウザでは、自動的にSIMD版のwasmビルドが使用されます。
-
-**絶賛開発中**
+WebAssembly の SIMD に対応しているブラウザでは、自動的に SIMD版 の wasm ビルドが使用されます。
 
 ## About Shiguredo's open source software
 
@@ -17,6 +16,26 @@ Please read https://github.com/shiguredo/oss/blob/master/README.en.md before use
 
 利用前に https://github.com/shiguredo/oss をお読みください。
 
+## 使い方
+
+以下のコマンドでパッケージがインストールできます:
+```console
+$ npm install --save @shiguredo/rnnoise-wasm
+$ ls node_modules/@shiguredo/rnnoise-wasm/
+rnnoise.d.ts rnnoise.js rnnoise.wasm rnnoise_simd.wasm
+```
+
+TypeScript での使用方法は次のようになります:
+```typescript
+import { Rnnoise } from "@shigredo/rnnoise-wasm/"
+
+// RNNoise の wasm ファイルをロード
+Rnnoise.load().then(|rnnoise| {
+    // 音声フレームにノイズ抑制処理を適用する
+    const frame = new Float32Array(...);
+    rnnoise.processFrame(frame);
+})
+```
 
 ## ライセンス
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Please read https://github.com/shiguredo/oss/blob/master/README.en.md before use
 以下のコマンドでパッケージがインストールできます:
 ```console
 $ npm install --save @shiguredo/rnnoise-wasm
-$ ls node_modules/@shiguredo/rnnoise-wasm/
-rnnoise.d.ts rnnoise.js rnnoise.wasm rnnoise_simd.wasm
+$ npm ls
+└── @shiguredo/rnnoise-wasm@2021.1.0
 ```
 
 TypeScript での使用方法は次のようになります:

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "@shiguredo/rnnoise-wasm",
       "version": "0.0.0",
       "license": "Apache-2.0",
-      "dependencies": {
-        "wasm-feature-detect": "^1.2.11"
-      },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^21.0.1",
         "@rollup/plugin-node-resolve": "^13.1.1",
@@ -29,7 +26,8 @@
         "ts-jest": "^27.1.2",
         "ts-node": "^10.4.0",
         "typedoc": "^0.22.10",
-        "typescript": "^4.5.4"
+        "typescript": "^4.5.4",
+        "wasm-feature-detect": "^1.2.11"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -5991,7 +5989,8 @@
     "node_modules/wasm-feature-detect": {
       "version": "1.2.11",
       "resolved": "https://registry.npmjs.org/wasm-feature-detect/-/wasm-feature-detect-1.2.11.tgz",
-      "integrity": "sha512-HUqwaodrQGaZgz1lZaNioIkog9tkeEJjrM3eq4aUL04whXOVDRc/o2EGb/8kV0QX411iAYWEqq7fMBmJ6dKS6w=="
+      "integrity": "sha512-HUqwaodrQGaZgz1lZaNioIkog9tkeEJjrM3eq4aUL04whXOVDRc/o2EGb/8kV0QX411iAYWEqq7fMBmJ6dKS6w==",
+      "dev": true
     },
     "node_modules/webidl-conversions": {
       "version": "6.1.0",
@@ -10719,7 +10718,8 @@
     "wasm-feature-detect": {
       "version": "1.2.11",
       "resolved": "https://registry.npmjs.org/wasm-feature-detect/-/wasm-feature-detect-1.2.11.tgz",
-      "integrity": "sha512-HUqwaodrQGaZgz1lZaNioIkog9tkeEJjrM3eq4aUL04whXOVDRc/o2EGb/8kV0QX411iAYWEqq7fMBmJ6dKS6w=="
+      "integrity": "sha512-HUqwaodrQGaZgz1lZaNioIkog9tkeEJjrM3eq4aUL04whXOVDRc/o2EGb/8kV0QX411iAYWEqq7fMBmJ6dKS6w==",
+      "dev": true
     },
     "webidl-conversions": {
       "version": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "@shiguredo/rnnoise-wasm",
-  "version": "0.0.0",
-  "description": "TODO",
+  "version": "2021.1.0",
+  "description": "Noise suppression library using RNNoise WebAssembly build",
   "main": "dist/rnnoise.js",
   "module": "dist/rnnoise.js",
+  "types": "dist/rnnoise.d.ts",
   "scripts": {
     "build": "rollup -c ./rollup.config.js && tsc --emitDeclarationOnly",
     "lint": "eslint --ext .ts ./src",
@@ -25,6 +26,9 @@
     "url": "https://github.com/shiguredo/rnnoise-wasm/issues"
   },
   "homepage": "https://github.com/shiguredo/rnnoise-wasm#readme",
+  "files": [
+    "dist"
+  ],
   "devDependencies": {
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-node-resolve": "^13.1.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "author": "Shiguredo Inc.",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/shiguredo/rnnoise-wasm/issues"
+    "url": "https://discord.gg/shiguredo"
   },
   "homepage": "https://github.com/shiguredo/rnnoise-wasm#readme",
   "files": [

--- a/package.json
+++ b/package.json
@@ -43,9 +43,7 @@
     "ts-jest": "^27.1.2",
     "ts-node": "^10.4.0",
     "typedoc": "^0.22.10",
-    "typescript": "^4.5.4"
-  },
-  "dependencies": {
+    "typescript": "^4.5.4",
     "wasm-feature-detect": "^1.2.11"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shiguredo/rnnoise-wasm",
   "version": "2021.1.0",
-  "description": "Noise suppression library using RNNoise WebAssembly build",
+  "description": "SIMD-accelerated WebAssembly build of RNNoise",
   "main": "dist/rnnoise.js",
   "module": "dist/rnnoise.js",
   "types": "dist/rnnoise.d.ts",


### PR DESCRIPTION
npmへのリリースに向けて、package.jsonやREADME.mdを更新しました。

変更点:
- README.md
  - "絶賛開発中"の文言を削除
  - 最低限の使用例を追加
  - その他細々とした文言修正
- package.json
  - "version"と"description"、"url"を更新
  - `dist/`ディレクトリが配布物に含まれるように"files"を追加
  - ブラウザのSIMD対応を判定するための"wasm-feature-detect"パッケージを"dependencies"から"devDependencies"に移動（npm登録時には `rnnoise.js` にバンドルされているので、利用側が新たにこの依存を取得する必要がないため）