### PR TITLE
UMDではなくES Module形式で配布ファイルを生成するように変更

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -60,7 +60,11 @@ export default {
   // globalTeardown: undefined,
 
   // A set of global variables that need to be available in all test environments
-  // globals: {},
+  globals: {
+    "ts-jest": {
+      "useESM": true
+    }
+  },
 
   // The maximum amount of workers used to run your tests. Can be specified as % or a number. E.g. maxWorkers: 10% will use 10% of your CPU amount + 1 as the maximum worker number. maxWorkers: 2 will use a maximum of 2 workers.
   // maxWorkers: "50%",
@@ -71,14 +75,11 @@ export default {
   // ],
 
   // An array of file extensions your modules use
-  // moduleFileExtensions: [
-  //   "js",
-  //   "jsx",
-  //   "ts",
-  //   "tsx",
-  //   "json",
-  //   "node"
-  // ],
+  moduleFileExtensions: [
+    "js",
+    "mjs",
+    "ts"
+  ],
 
   // A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
   // moduleNameMapper: {},
@@ -93,7 +94,7 @@ export default {
   // notifyMode: "failure-change",
 
   // A preset that is used as a base for Jest's configuration
-  // preset: undefined,
+  preset: "ts-jest/presets/default-esm",
 
   // Run tests from one or more projects
   // projects: undefined,

--- a/package.json
+++ b/package.json
@@ -2,9 +2,10 @@
   "name": "@shiguredo/rnnoise-wasm",
   "version": "2021.1.0",
   "description": "SIMD-accelerated WebAssembly build of RNNoise",
-  "main": "dist/rnnoise.js",
-  "module": "dist/rnnoise.js",
+  "main": "dist/rnnoise.mjs",
+  "module": "dist/rnnoise.mjs",
   "types": "dist/rnnoise.d.ts",
+  "type": "module",
   "scripts": {
     "build": "rollup -c ./rollup.config.js && tsc --emitDeclarationOnly",
     "lint": "eslint --ext .ts ./src",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "rollup -c ./rollup.config.js && tsc --emitDeclarationOnly",
     "lint": "eslint --ext .ts ./src",
     "fmt": "prettier --write src",
-    "test": "jest",
+    "test": "NODE_OPTIONS=--experimental-vm-modules npx jest",
     "doc": "typedoc"
   },
   "repository": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -22,8 +22,8 @@ export default [
     ],
     output: {
       sourcemap: false,
-      file: './dist/rnnoise.js',
-      format: 'umd',
+      file: './dist/rnnoise.mjs',
+      format: 'module',
       name: 'Shiguredo',
       extend: true,
       banner: banner,

--- a/tests/rnnoise.test.ts
+++ b/tests/rnnoise.test.ts
@@ -1,3 +1,11 @@
+// emscripten-v3.1.0が出力したファイルをバンドルした".mjs"ファイルを、nodeから読み込もうとするとエラーになるので、
+// https://github.com/emscripten-core/emscripten/issues/11792#issuecomment-877120580 に記載のワークアラウンドで対処している。
+//
+// TODO: emscripten側に正式な対応が入ったら、そちらを使用してこのワークアラウンドは消す
+import { createRequire } from "module";
+globalThis.__dirname = "dist/";
+globalThis.require = createRequire(import.meta.url);
+
 import { Rnnoise } from "../dist/rnnoise";
 
 test("Create instance and process a frame (non SIMD)", async () => {


### PR DESCRIPTION
rnnoise-wasmは、ブラウザからではなく別のTypeScriptパッケージから利用されることを想定しているため、出力形式をそれに適したES Moduleに変更しました。　

主な変更点:
- pacakge.json
   - ESModuleであることを示すために`"type": "module"`を追加
   - "main"と"module"で指定しているファイルの拡張子を".js"から".mjs"に変更
- rollup.config.js
   - 出力ファイルの拡張子を".js"から".mjs"に変更
   - フォーマットも"umd"から"module"に変更
- その他
   - ユニットテスト(jest)で".mjs"ファイルを扱えるようにするために諸々の変更を適用