### PR TITLE
ビルド用のGitHub Actionsジョブを追加

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,126 @@
+name: build
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build-assets:
+    name: Build WASM and JS files
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: mymindstorm/setup-emsdk@v11
+        with:
+          version: 3.1.0
+      - run: emcc --version
+      - run: sudo apt install -y autoconf automake
+      - run: ./build-rnnoise.sh
+
+      # [注意] setup-emsdkが古いnode/npmをインストールしてしまうので、
+      #        setup-nodeはその後に呼び出す必要がある。
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
+          cache: npm
+      - run: node --version
+      - run: npm --version
+      - run: npm install
+      - run: npm run build
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: rnnoise-wasm-dist
+          path: dist/
+
+  create-release-draft:
+    name: Create GitHub Release Draft
+    runs-on: ubuntu-latest
+    needs:
+      - build-assets
+    outputs:
+      version: ${{ steps.get_version.outputs.VERSION }}
+      upload-url: ${{ steps.create-release.outputs.upload_url }}
+    steps:
+      - name: Get the version
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+      - id: create-release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.get_version.outputs.VERSION }}
+          release_name: ${{ steps.get_version.outputs.VERSION }}
+          draft: true
+          prerelease: true
+
+  upload-assets:
+    name: Upload WASM and JS files
+    runs-on: ubuntu-latest
+    needs:
+      - create-release-draft
+    steps:
+      - name: Download Artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: rnnoise-wasm-dist
+
+      - uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create-release-draft.outputs.upload-url }}
+          asset_path: rnnoise.mjs
+          asset_name: rnnoise.mjs
+          asset_content_type: text/javascript
+
+      - uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create-release-draft.outputs.upload-url }}
+          asset_path: rnnoise.d.ts
+          asset_name: rnnoise.d.ts
+          asset_content_type: application/typescript
+
+      - uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create-release-draft.outputs.upload-url }}
+          asset_path: rnnoise.wasm
+          asset_name: rnnoise.wasm
+          asset_content_type: application/wasm
+
+      - uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create-release-draft.outputs.upload-url }}
+          asset_path: rnnoise_simd.wasm
+          asset_name: rnnoise_simd.wasm
+          asset_content_type: application/wasm
+
+  notification:
+    name: Slack Notification
+    runs-on: ubuntu-latest
+    needs:
+      - build-assets
+      - create-release-draft
+      - upload-assets
+    if: always()
+    steps:
+      - uses: actions/checkout@v2
+      - uses: rtCamp/action-slack-notify@v2
+        if: |
+          needs.build-assets.result == 'failure' ||
+          needs.create-release-draft.result == 'failure' ||
+          needs.upload-assets.result == 'failure'
+        env:
+          SLACK_CHANNEL: media-processors
+          SLACK_COLOR: danger
+          SLACK_TITLE: Failure build
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
GitHubタグをトリガーにして実行される、以下を行うビルド用のジョブを追加しました:
- RNNoiseのwasmファイルのビルド (`./build-rnnoise.sh`)
- npm登録用のrnnoise.mjsファイルの生成 (`npm run build`)
- GitHubリリースのドラフトを作成
- リリースドラフトのアセットとしてビルドされたファイル群をアップロード

リリースドラフトのイメージ:
<img width="1287" alt="スクリーンショット 2021-12-28 15 32 58" src="https://user-images.githubusercontent.com/181413/147535666-896fd2f8-455b-4ce4-aae6-22cf0063a0ea.png">

アセットのファイル名の形式としては、途中にバージョン番号を含んだもの (e.g., "rnnoise-2021.1.0.mjs") をよく見かけますが、wasmファイルの名前を変更してしまうと「HTMLからGitHubリリースにあるjsファイルを直接読み込んで実行」といったことができなくなってしまうので、今回はあえてそのままのファイル名を使用しています。
（ただ、rnnoise-wasmは上記の使用方法はあまり想定していないものでもあるので、バージョン番号を含んだ形式の方が良ければ変更します）
