### PR TITLE
npmリリース準備を行うためのスクリプトを追加

### DIFF
--- a/prepare-npm-publish.sh
+++ b/prepare-npm-publish.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# npmリリースの準備を行うためのスクリプトです。
+# 実際にリリースコマンド (`$ npm publish --access public`) の実行までは行いません。
+# また、事前に該当バージョンのGitHubリリースの作成とGitHub Actionsによるwasmのビルドが実施されている必要があります。
+#
+# [使い方]
+# $ ./prepare-npm-publish.sh ${バージョン番号}
+
+set -eux
+
+VERSION=$1
+
+# バージョンチェック
+ACTUAL_VERSION=$(jq -r .version package.json)
+if [ "$VERSION" != "$ACTUAL_VERSION" ]; then
+  echo "The specified version '$VERSION' doesn't match with the actual version '$ACTUAL_VERSION' in package.json."
+  exit 1
+fi
+
+# ビルド済みファイルのダウンロード
+rm -rf dist
+mkdir dist
+cd dist/
+curl -fsSLO https://github.com/shiguredo/rnnoise-wasm/releases/download/$VERSION/rnnoise.mjs
+curl -fsSLO https://github.com/shiguredo/rnnoise-wasm/releases/download/$VERSION/rnnoise.d.ts
+curl -fsSLO https://github.com/shiguredo/rnnoise-wasm/releases/download/$VERSION/rnnoise.wasm
+curl -fsSLO https://github.com/shiguredo/rnnoise-wasm/releases/download/$VERSION/rnnoise_simd.wasm
+cd ../
+
+# ドライラン
+npm publish --dry-run
+
+echo 'Done!'
+
+echo 'Please execute the following command to publish the version to the npm:'
+echo '$ npm publish --access public'


### PR DESCRIPTION
タイトルの通り `prepare-npm-publish.sh`というスクリプトを追加しました。
数十行程度の簡単なスクリプトなので、詳細はスクリプトのコードやコメントを参照してください。

## 実行結果

バージョン指定が適切な場合:
```
$ ./prepare-npm-publish.sh 2021.1.0                
+ VERSION=2021.1.0
++ jq -r .version package.json
+ ACTUAL_VERSION=2021.1.0
+ '[' 2021.1.0 '!=' 2021.1.0 ']'
+ rm -rf dist
+ mkdir dist
+ cd dist/
+ curl -fsSLO https://github.com/shiguredo/rnnoise-wasm/releases/download/2021.1.0/rnnoise.mjs
+ curl -fsSLO https://github.com/shiguredo/rnnoise-wasm/releases/download/2021.1.0/rnnoise.d.ts
+ curl -fsSLO https://github.com/shiguredo/rnnoise-wasm/releases/download/2021.1.0/rnnoise.wasm
+ curl -fsSLO https://github.com/shiguredo/rnnoise-wasm/releases/download/2021.1.0/rnnoise_simd.wasm
+ cd ../
+ npm publish --dry-run
npm notice 
npm notice 📦  @shiguredo/rnnoise-wasm@2021.1.0
npm notice === Tarball Contents === 
npm notice 10.2kB  LICENSE               
npm notice 2.1kB   README.md             
npm notice 129.1kB dist/rnnoise_simd.wasm
npm notice 2.5kB   dist/rnnoise.d.ts     
npm notice 99.4kB  dist/rnnoise.mjs      
npm notice 124.6kB dist/rnnoise.wasm     
npm notice 1.5kB   package.json          
npm notice === Tarball Details === 
npm notice name:          @shiguredo/rnnoise-wasm                 
npm notice version:       2021.1.0                                
npm notice filename:      @shiguredo/rnnoise-wasm-2021.1.0.tgz    
npm notice package size:  233.2 kB                                
npm notice unpacked size: 369.4 kB                                
npm notice shasum:        f3f595be13d7d9bf3f08aa9e0ff84258fc036b0e
npm notice integrity:     sha512-P3WtFSki+f8cq[...]7Veu7HI5Nkl+A==
npm notice total files:   7                                       
npm notice 
+ @shiguredo/rnnoise-wasm@2021.1.0
+ echo 'Done!'
Done!
+ echo 'Please execute the following command to publish the version to the npm:'
Please execute the following command to publish the version to the npm:
+ echo '$ npm publish --access public'
$ npm publish --access public
```

バージョン指定が不適切な場合:
```
$ ./prepare-npm-publish.sh 1.2.3   
+ VERSION=1.2.3
++ jq -r .version package.json
+ ACTUAL_VERSION=2021.1.0
+ '[' 1.2.3 '!=' 2021.1.0 ']'
+ echo 'The specified version '\''1.2.3'\'' doesn'\''t match with the actual version '\''2021.1.0'\'' in package.json.'
The specified version '1.2.3' doesn't match with the actual version '2021.1.0' in package.json.
+ exit 1
```